### PR TITLE
Using int is easy to result in memory overflow on Linux.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/lxzan/php_session_decoder
+
+require github.com/yvasiyarov/php_session_decoder v0.0.0-20180803065642-a065a3b0b7d1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/yvasiyarov/php_session_decoder v0.0.0-20180803065642-a065a3b0b7d1 h1:p/oCPaHILUSplKqfjFyvivh4UglLHDtzs6F/wfOzyJE=
+github.com/yvasiyarov/php_session_decoder v0.0.0-20180803065642-a065a3b0b7d1/go.mod h1:96w6piyt5Z2E86/J6EQPEn76UR4scqR9bS+Y9iJF/Og=

--- a/php_serialize/unserialize.go
+++ b/php_serialize/unserialize.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-const UNSERIALIZABLE_OBJECT_MAX_LEN = 10 * 1024 * 1024 * 1024
+const UNSERIALIZABLE_OBJECT_MAX_LEN int64 = 10 * 1024 * 1024 * 1024
 
 func UnSerialize(s string) (PhpValue, error) {
 	decoder := NewUnSerializer(s)
@@ -263,7 +263,7 @@ func (self *UnSerializer) readLen() int {
 	} else {
 		if val, err = strconv.Atoi(raw); err != nil {
 			self.saveError(fmt.Errorf("php_serialize: Unable to convert %s to int: %v", raw, err))
-		} else if val > UNSERIALIZABLE_OBJECT_MAX_LEN {
+		} else if int64(val) > UNSERIALIZABLE_OBJECT_MAX_LEN {
 			self.saveError(fmt.Errorf("php_serialize: Unserializable object length looks too big(%d). If you are sure you wanna unserialise it, please increase UNSERIALIZABLE_OBJECT_MAX_LEN const", val))
 			val = 0
 		}


### PR DESCRIPTION
Using int is easy to result in memory overflow on Linux.